### PR TITLE
fix(docs): openocd repository

### DIFF
--- a/_posts/releases/openocd/2023-09-04-openocd-v0-12-0-2-released.md
+++ b/_posts/releases/openocd/2023-09-04-openocd-v0-12-0-2-released.md
@@ -125,7 +125,7 @@ The xPack OpenOCD generally follows the official
 The current version is based on:
 
 - OpenOCD version {{ page.upstream_version }}, the development commit
-[{{ page.upstream_commit }}](https://github.com/xpack-dev-tools/openocd/commit/{{ page.upstream_commit }}/)
+[{{ page.upstream_commit }}](https://github.com/openocd-org/openocd/commit/{{ page.upstream_commit }}/)
 from {{ page.upstream_release_date }}.
 
 ## Changes


### PR DESCRIPTION
This PR should fix issue with url of openocd development commit:
https://xpack.github.io/blog/2023/09/04/openocd-v0-12-0-2-released/#compliance

It is https://github.com/xpack-dev-tools/openocd/commit/18281b0/ but should be https://github.com/openocd-org/openocd/commit/18281b0/
